### PR TITLE
DEV-51085: fix access modifiers in response structs

### DIFF
--- a/CuralateKit/Responses/GetMediaResponse.swift
+++ b/CuralateKit/Responses/GetMediaResponse.swift
@@ -6,35 +6,35 @@ import Foundation
 
 public struct GetMediaResponse: Decodable {
     
-    let data: GetMediaResponseData
-    let metadata: GetMediaResponseMetadata
+    public let data: GetMediaResponseData
+    public let metadata: GetMediaResponseMetadata
     // We repurpose this property to simplify pagination on subsequent requests, which is why it needs to be mutable.
-    var paging: GetMediaResponsePaging
+    public var paging: GetMediaResponsePaging
     
     // Only present if the API sends an error
-    let code: String?
-    let msg: String?
-    let errorId: String?
+    public let code: String?
+    public let msg: String?
+    public let errorId: String?
 }
 
 public struct GetMediaResponseData: Decodable {
-    let items: [MediaItem]
-    let resultsCount: Int
+    public let items: [MediaItem]
+    public let resultsCount: Int
 }
 
 public struct GetMediaResponseMetadata: Decodable {
-    let traceId: String
-    let requestId: String?
-    let firstPartyCuid: String?
-    let curalateUserId: String?
-    let customCuralateUserId: String?
+    public let traceId: String
+    public let requestId: String?
+    public let firstPartyCuid: String?
+    public let curalateUserId: String?
+    public let customCuralateUserId: String?
     // TODO: add PDP metadata
 }
 
 public struct GetMediaResponsePaging: Decodable {
     // We repurpose this property to simplify pagination on subsequent requests, which is why it needs to be mutable.
-    var cursors: PagingCursor
-    let next: URL?
-    let previous: URL?
+    public var cursors: PagingCursor
+    public let next: URL?
+    public let previous: URL?
 }
 

--- a/CuralateKit/Responses/Image.swift
+++ b/CuralateKit/Responses/Image.swift
@@ -5,5 +5,5 @@
 import Foundation
 
 public struct Image : Decodable {
-    let link: URL
+    public let link: URL
 }

--- a/CuralateKit/Responses/MediaItem.swift
+++ b/CuralateKit/Responses/MediaItem.swift
@@ -5,9 +5,9 @@
 import Foundation
 
 public struct MediaItem: Decodable {
-    let id: String
-    let source: MediaItemSource
-    let labels: [String]
-    let media: NetworkMedia
-    let products: [MediaItemProduct]
+    public let id: String
+    public let source: MediaItemSource
+    public let labels: [String]
+    public let media: NetworkMedia
+    public let products: [MediaItemProduct]
 }

--- a/CuralateKit/Responses/MediaItemProduct.swift
+++ b/CuralateKit/Responses/MediaItemProduct.swift
@@ -5,13 +5,13 @@
 import Foundation
 
 public struct MediaItemProduct: Decodable {
-    let id: String
-    let name: String
-    let images: [NetworkPhoto]
-    let link: URL
-    let price: Price?
-    let metadata: [String : String]?
-    let spatialTag: SpatialTag?
+    public let id: String
+    public let name: String
+    public let images: [NetworkPhoto]
+    public let link: URL
+    public let price: Price?
+    public let metadata: [String : String]?
+    public let spatialTag: SpatialTag?
 }
 
 public struct SpatialTag: Decodable {

--- a/CuralateKit/Responses/MediaItemSource.swift
+++ b/CuralateKit/Responses/MediaItemSource.swift
@@ -5,16 +5,16 @@
 import Foundation
 
 public struct MediaItemSource: Decodable {
-    let type: ItemType
-    let postedTimestamp: Int
-    let user: User?
-    let link: URL?
-    let caption: String?
-    let commentCount: Int?
-    let likeCount: Int?
-    let repinCount: Int?
-    let location: Location?
-    let sourceId: String?
+    public let type: ItemType
+    public let postedTimestamp: Int
+    public let user: User?
+    public let link: URL?
+    public let caption: String?
+    public let commentCount: Int?
+    public let likeCount: Int?
+    public let repinCount: Int?
+    public let location: Location?
+    public let sourceId: String?
 }
 
 public enum ItemType: String, Decodable {
@@ -27,24 +27,24 @@ public enum ItemType: String, Decodable {
 }
 
 public struct User: Decodable {
-    let username: String?
-    let displayName: String?
-    let link: URL?
-    let image: ThumbnailPhoto?
-    let followerCount: Int?
-    let followingCount: Int?
+    public let username: String?
+    public let displayName: String?
+    public let link: URL?
+    public let image: ThumbnailPhoto?
+    public let followerCount: Int?
+    public let followingCount: Int?
 }
 
 public struct Location: Decodable {
-    let name: String?
-    let latitude: Float?
-    let longitude: Float?
+    public let name: String?
+    public let latitude: Float?
+    public let longitude: Float?
 }
 
 public struct ThumbnailPhoto: Decodable {
-    let original: Image
-    let small: Image
-    let medium: Image
-    let smallSquare: Image
-    let mediumSquare: Image
+    public let original: Image
+    public let small: Image
+    public let medium: Image
+    public let smallSquare: Image
+    public let mediumSquare: Image
 }

--- a/CuralateKit/Responses/NetworkGif.swift
+++ b/CuralateKit/Responses/NetworkGif.swift
@@ -5,6 +5,6 @@
 import Foundation
 
 public struct NetworkGif: Decodable {
-    let id: String
-    let original: Image
+    public let id: String
+    public let original: Image
 }

--- a/CuralateKit/Responses/NetworkPhoto.swift
+++ b/CuralateKit/Responses/NetworkPhoto.swift
@@ -5,14 +5,14 @@
 import Foundation
 
 public struct NetworkPhoto: Decodable {
-    let id: String
-    let original: Image
-    let small: Image
-    let medium: Image
-    let large: Image
-    let extraLarge: Image
-    let smallSquare: Image
-    let mediumSquare: Image
-    let largeSquare: Image
-    let extraLargeSquare: Image
+    public let id: String
+    public let original: Image
+    public let small: Image
+    public let medium: Image
+    public let large: Image
+    public let extraLarge: Image
+    public let smallSquare: Image
+    public let mediumSquare: Image
+    public let largeSquare: Image
+    public let extraLargeSquare: Image
 }

--- a/CuralateKit/Responses/NetworkVideo.swift
+++ b/CuralateKit/Responses/NetworkVideo.swift
@@ -5,8 +5,8 @@
 import Foundation
 
 public struct NetworkVideo: Decodable {
-    let original: Video
-    let highQuality: Video
-    let lowQuality: Video
-    let poster: NetworkPhoto?
+    public let original: Video
+    public let highQuality: Video
+    public let lowQuality: Video
+    public let poster: NetworkPhoto?
 }

--- a/CuralateKit/Responses/Video.swift
+++ b/CuralateKit/Responses/Video.swift
@@ -5,5 +5,5 @@
 import Foundation
 
 public struct Video : Decodable {
-    let link: URL
+    public let link: URL
 }


### PR DESCRIPTION
#### :ticket: [JIRA](https://curalate.atlassian.net/browse/DEV-51085)

#### :horse: Summary

Fix access modifiers in API response data structures.

#### :book: Detailed Description

By default, struct properties have `internal` access control -- which means that they can be accessed from code within the same module, but not from outside of that module. This will make CuralateKit unusable for developers who pull it in via Carthage, etc. This PR updates the access level to public.

#### :clap: Testing
- [x] Unit tests pass.