### PR TITLE
DEV-51084: Add support for Carthage builds

### DIFF
--- a/CuralateKit.xcodeproj/xcshareddata/xcschemes/CuralateKit.xcscheme
+++ b/CuralateKit.xcodeproj/xcshareddata/xcschemes/CuralateKit.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "490F1C7822FB7A45008DBA11"
+               BuildableName = "CuralateKit.framework"
+               BlueprintName = "CuralateKit"
+               ReferencedContainer = "container:CuralateKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4927A383239860E100050296"
+               BuildableName = "CuralateKitTests.xctest"
+               BlueprintName = "CuralateKitTests"
+               ReferencedContainer = "container:CuralateKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "490F1C7822FB7A45008DBA11"
+            BuildableName = "CuralateKit.framework"
+            BlueprintName = "CuralateKit"
+            ReferencedContainer = "container:CuralateKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CuralateKit.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/CuralateKit.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ For questions or support, please contact your Curalate Account Manager or suppor
 
 ## Installation
 
+### Carthage
+
+```
+github "curalate/CuralateKit" ~> 0.1.2
+```
+
 ### CocoaPods
 
 Instructions for installation via CocoaPods is coming soon.
-
-### Carthage [COMING SOON]
-
-Instructions for installation via Carthage is coming soon.
 
 ## Usage
 


### PR DESCRIPTION
#### :ticket: [JIRA](https://curalate.atlassian.net/browse/DEV-51084)

#### :horse: Summary

Add support for Carthage builds

#### :book: Detailed Description

To enable Carthage builds, we need to make sure that we've marked the CuralateKit scheme as Shared in Xcode. This PR includes a configuration change to do this.

I've also updated the README file to include instructions for adding CuralateKit to a Carthage project.

#### :clap: Testing
- [x] Unit tests pass.
- [x] `carthage build --archive` now runs.
