### PR TITLE
PD-286422:Make Price properties public in MediaItemProductand update the test case

### DIFF
--- a/Sources/CuralateKit/Responses/MediaItemProduct.swift
+++ b/Sources/CuralateKit/Responses/MediaItemProduct.swift
@@ -15,17 +15,17 @@ public struct MediaItemProduct: Decodable {
 }
 
 public struct SpatialTag: Decodable {
-    let x: Float
-    let y: Float
-    let label: String
+     public let x: Float
+     public let y: Float
+     public let label: String
 }
 
 public struct Price: Decodable {
-    let display: String
-    let value: Decimal?
-    let currencySymbol: String?
-    let currencyCode: String?
-    let saleValue: Decimal?
-    let saleDisplay: String?
-    let isOnSale: Bool?
+    public let display: String
+    public let value: Decimal?
+    public let currencySymbol: String?
+    public let currencyCode: String?
+    public let saleValue: Decimal?
+    public let saleDisplay: String?
+    public let isOnSale: Bool?
 }

--- a/Sources/CuralateKit/Responses/MediaItemSource.swift
+++ b/Sources/CuralateKit/Responses/MediaItemSource.swift
@@ -21,8 +21,10 @@ public enum ItemType: String, Decodable {
     case pinterest
     case facebook
     case instagram
+    case tiktok
     case twitter
     case tumblr
+    case youtube
     case mediaimport
 }
 

--- a/Tests/CuralateKitTests/CuralateKitTests.swift
+++ b/Tests/CuralateKitTests/CuralateKitTests.swift
@@ -74,6 +74,9 @@ class CuralateKitTests: XCTestCase {
             XCTAssertEqual(product1?.price?.value, 140)
             XCTAssertEqual(product1?.price?.currencySymbol, "$")
             XCTAssertEqual(product1?.price?.currencyCode, "USD")
+            XCTAssertEqual(product1?.price?.saleValue, 99)
+            XCTAssertEqual(product1?.price?.saleDisplay, "99")
+            XCTAssertEqual(product1?.price?.isOnSale, true)
             XCTAssertEqual(product1?.link, URL(string:"https://www.example.com/product1"))
             XCTAssertEqual(product1?.metadata, [
                 "manufacturer": "Manufacturer1",

--- a/Tests/CuralateKitTests/TestResponses.swift
+++ b/Tests/CuralateKitTests/TestResponses.swift
@@ -116,7 +116,10 @@ struct TestResponses {
                             "display": "140",
                             "value": 140,
                             "currencySymbol": "$",
-                            "currencyCode": "USD"
+                            "currencyCode": "USD",
+                            "saleValue": 99,
+                            "saleDisplay": "99",
+                            "isOnSale": true
                         },
                         "link": "https://www.example.com/product1",
                         "metadata": {


### PR DESCRIPTION
#### :ticket: [JIRA](https://bazaarvoice.atlassian.net/browse/PD-286422)

#### :horse: Summary
This PR updates the MediaItemProduct.swift file to expose properties within the Price and SpatialTag structs by marking them as public. Also update the enum in the MediaItemSource.swift to new sources which were added.

#### :book: Detailed Description
Previously, these properties (x, y, label, display, value, currencySymbol, etc., in Price and SpatialTag ) defaulted to internal access. This prevented client applications integrating with the CuralateKit SDK from directly accessing these valuable product details.With this changes, client should be able to access all these properties

Additionally while testing we noticed that if media API has the data from the `youtube` and the `tiktok`,  clients were unable to access those do the `dataCorrupted` error.


#### :clap: Testing
- [ ] Unit tests pass.
- [ ] Project builds.
