### PR TITLE
PD-308416:Support to Sampling Content

### DIFF
--- a/Sources/CuralateKit/Responses/MediaItemSource.swift
+++ b/Sources/CuralateKit/Responses/MediaItemSource.swift
@@ -26,6 +26,7 @@ public enum ItemType: String, Decodable {
     case tumblr
     case youtube
     case mediaimport
+    case bazaarvoice
 }
 
 public struct User: Decodable {


### PR DESCRIPTION
#### :ticket: [JIRA](https://bazaarvoice.atlassian.net/browse/PD-308416)


**Description**
This PR updates the SDK to support Sampling content where source.type can be bazaarvoice.

Previously, decoding failed when the API returned bazaarvoice in media item source type, resulting in a decoding error and request failure.  
With this change, bazaarvoice is now treated as a valid ItemType and decoded successfully.

**What changed**
- Added bazaarvoice to the ItemType enum used for media source decoding.
- Kept enum decoding strict (only declared source types are accepted).

**Why**
Sampling responses can include source.type = bazaarvoice.  
The SDK needs to recognize this value so getMedia responses decode correctly.

**Validation**
- Verified build passes with local SDK integration.
- Verified app can fetch media without failing on bazaarvoice source type.

**Impact**
- Backward compatible for existing source types.
- Fixes decoding failures for Sampling responses containing bazaarvoice.
